### PR TITLE
[BUGFIX] Fix maxWidth and maxHeight not considered in target file width and height

### DIFF
--- a/Classes/Resource/Processing/DeferredImageProcessor.php
+++ b/Classes/Resource/Processing/DeferredImageProcessor.php
@@ -2,8 +2,7 @@
 
 namespace WEBcoast\DeferredImageProcessing\Resource\Processing;
 
-use TYPO3\CMS\Core\Imaging\GraphicalFunctions;
-use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Core\Imaging\ImageDimension;
 use TYPO3\CMS\Core\Resource\Processing\LocalImageProcessor;
 use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
 use TYPO3\CMS\Core\Resource\Processing\TaskTypeRegistry;
@@ -39,8 +38,8 @@ class DeferredImageProcessor extends LocalImageProcessor
                 return;
             }
 
-            $imageDimensions = $this->getTargetDimensions($task);
-            if ($imageDimensions[0] === $task->getTargetFile()->getOriginalFile()->getProperty('width') && $imageDimensions[1] === $task->getTargetFile()->getOriginalFile()->getProperty('height')) {
+            $imageDimensions = ImageDimension::fromProcessingTask($task);
+            if ($imageDimensions->getWidth() === $task->getTargetFile()->getOriginalFile()->getProperty('width') && $imageDimensions->getHeight() === $task->getTargetFile()->getOriginalFile()->getProperty('height')) {
                 // If the target image dimensions are identical to the original file, do not process, but use the original file
                 $task->setExecuted(true);
                 $task->getTargetFile()->setUsesOriginalFile();
@@ -57,27 +56,9 @@ class DeferredImageProcessor extends LocalImageProcessor
                 $task->setExecuted(true);
                 $task->getTargetFile()->setName($task->getTargetFileName());
                 $task->getTargetFile()->updateProperties(
-                    ['width' => $imageDimensions[0], 'height' => $imageDimensions[1], 'checksum' => $task->getConfigurationChecksum()]
+                    ['width' => $imageDimensions->getWidth(), 'height' => $imageDimensions->getHeight(), 'checksum' => $task->getConfigurationChecksum()]
                 );
             }
         }
-    }
-
-    protected function getTargetDimensions(TaskInterface $task)
-    {
-        $graphicalFunctions = GeneralUtility::makeInstance(GraphicalFunctions::class);
-        $originalFileInfo = $graphicalFunctions->getImageDimensions($task->getSourceFile()->getForLocalProcessing(false));
-        $configuration = $task->getConfiguration();
-
-        $crop = $configuration['crop'] ?? null;
-        if ($crop instanceof Area) {
-            $crop = $crop->asArray();
-        }
-        if (isset($crop['width']) && isset($crop['height'])) {
-            $originalFileInfo[0] = $crop['width'];
-            $originalFileInfo[1] = $crop['height'];
-        }
-
-        return $graphicalFunctions->getImageScale($originalFileInfo, $configuration['width'], $configuration['height'], $configuration);
     }
 }


### PR DESCRIPTION
Hi @thommyhh 

The current implementation does not account for `maxWidth` nor `maxHeight` configurations. In the list view this can lead to low resolution preview images being shown with their full width and height.

I borrowed the implementation from the TYPO3 core in `TYPO3\CMS\Backend\Resource\Processing\DeferredBackendImageProcessor`, which should account for all the possible processing instructions.