### PR TITLE
[BUGFIX] Fix images from fallback storage can not be processed

### DIFF
--- a/Classes/Middleware/ImageProcessor.php
+++ b/Classes/Middleware/ImageProcessor.php
@@ -8,7 +8,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
-use TYPO3\CMS\Core\Resource\StorageRepository;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WEBcoast\DeferredImageProcessing\Resource\Processing\FileRepository;
 
@@ -19,7 +18,7 @@ class ImageProcessor implements MiddlewareInterface
         $path = ltrim($request->getUri()->getPath(), '/');
 
         if (($processingInstructions = FileRepository::getProcessingInstructionsByUrl($path)) !== false) {
-            $storage = GeneralUtility::makeInstance(StorageRepository::class)->findByUid($processingInstructions['storage']);
+            $storage = GeneralUtility::makeInstance(ResourceFactory::class)->getStorageObject($processingInstructions['storage']);
             $configuration = unserialize($processingInstructions['configuration']);
             $configuration['deferred'] = true;
             $processedFile = $storage->processFile(


### PR DESCRIPTION
@thommyhh It seems that images that have storage uid `0` (Fallback Storage) can not be processed as this storage can not be found using the `StorageRepository`. Usually this happens for Images that are outside `fileadmin`, e.g. in `typo3conf/ext`. The same implementation is used in several places across the TYPO3 Core, e.g. in `ProcessedFile::reconstituteFromDatabaseRecord`.

Thanks for having a look at this and sharing this extension in the first place!