### PR TITLE
[BUGFIX] Fix preview images for non-public storages not working

### DIFF
--- a/Classes/Resource/Processing/DeferredImageProcessor.php
+++ b/Classes/Resource/Processing/DeferredImageProcessor.php
@@ -21,7 +21,7 @@ class DeferredImageProcessor extends LocalImageProcessor
 
     public function processTask(TaskInterface $task): void
     {
-        if (isset($task->getConfiguration()['deferred'])) {
+        if (isset($task->getConfiguration()['deferred']) || !$task->getTargetFile()->getStorage()->isPublic()) {
             $configuration = $task->getConfiguration();
             unset($configuration['deferred']);
             $localTask = GeneralUtility::makeInstance(TaskTypeRegistry::class)->getTaskForType($task->getType() . '.' . $task->getName(), $task->getTargetFile(), $configuration);


### PR DESCRIPTION
When generating preview images for non-public storages, TYPO3 routes the requests to the images through the eID `FileDumpController`. An image URL might look like this:

```
<img src="https://localhost/index.php?eID=dumpFile&t=p&p=67231&token=xy" />
```

<img width="746" alt="Screenshot 2021-06-14 at 18 09 34" src="https://user-images.githubusercontent.com/4113819/122004958-58f29680-cdb5-11eb-8c3d-1048aab1f935.png">

This however does not work when the image processing is deferred. Thus I would suggest to simply disable the deferring for non-public storages.

You can test this by setting the `is_public` flag to `false` for a given storage, removing the files in the `_processed_` folder and then open an edit view containing an image reference. 