### PR TITLE
[BUGFIX] Normalize public URLs by removing leading slash

### DIFF
--- a/Classes/Middleware/ImageProcessor.php
+++ b/Classes/Middleware/ImageProcessor.php
@@ -10,12 +10,13 @@ use Psr\Http\Server\RequestHandlerInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WEBcoast\DeferredImageProcessing\Resource\Processing\FileRepository;
+use WEBcoast\DeferredImageProcessing\Utility\PathUtility;
 
 class ImageProcessor implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $path = ltrim($request->getUri()->getPath(), '/');
+        $path = PathUtility::stripLeadingSlash($request->getUri()->getPath());
 
         if (($processingInstructions = FileRepository::getProcessingInstructionsByUrl($path)) !== false) {
             $storage = GeneralUtility::makeInstance(ResourceFactory::class)->getStorageObject($processingInstructions['storage']);

--- a/Classes/Resource/Processing/FileRepository.php
+++ b/Classes/Resource/Processing/FileRepository.php
@@ -5,6 +5,7 @@ namespace WEBcoast\DeferredImageProcessing\Resource\Processing;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Resource\Processing\TaskInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use WEBcoast\DeferredImageProcessing\Utility\PathUtility;
 
 class FileRepository
 {
@@ -32,7 +33,7 @@ class FileRepository
         $queryBuilder->insert(self::TABLE)
             ->values([
                 'storage' => $queryBuilder->createNamedParameter($task->getSourceFile()->getStorage()->getUid() ,\PDO::PARAM_INT),
-                'public_url' => $queryBuilder->createNamedParameter($task->getTargetFile()->getPublicUrl()),
+                'public_url' => $queryBuilder->createNamedParameter(PathUtility::stripLeadingSlash($task->getTargetFile()->getPublicUrl())),
                 'source_file' => $queryBuilder->createNamedParameter($task->getSourceFile()->getUid(), \PDO::PARAM_INT),
                 'task_type' => $queryBuilder->createNamedParameter($task->getType()),
                 'task_name' => $queryBuilder->createNamedParameter($task->getName()),
@@ -43,12 +44,22 @@ class FileRepository
         return $queryBuilder->execute();
     }
 
+    public static function getProcessingInstructions(int $maxResults = 100)
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->select('*')
+            ->from(self::TABLE)
+            ->setMaxResults($maxResults);
+
+        return $queryBuilder->execute()->fetchAllAssociative();
+    }
+
     public static function getProcessingInstructionsByUrl($url)
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->select('*')
             ->from(self::TABLE)
-            ->where($queryBuilder->expr()->eq('public_url', $queryBuilder->createNamedParameter($url)));
+            ->where($queryBuilder->expr()->eq('public_url', $queryBuilder->createNamedParameter(PathUtility::stripLeadingSlash($url))));
 
         return $queryBuilder->execute()->fetch();
     }
@@ -57,7 +68,7 @@ class FileRepository
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->update(self::TABLE)
-            ->set('public_url', $task->getTargetFile()->getPublicUrl())
+            ->set('public_url', PathUtility::stripLeadingSlash($task->getTargetFile()->getPublicUrl()))
             ->where(
                 $queryBuilder->expr()->eq('storage', $queryBuilder->createNamedParameter($task->getSourceFile()->getStorage()->getUid())),
                 $queryBuilder->expr()->eq('source_file', $queryBuilder->createNamedParameter($task->getSourceFile()->getUid())),

--- a/Classes/Utility/PathUtility.php
+++ b/Classes/Utility/PathUtility.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace WEBcoast\DeferredImageProcessing\Utility;
+
+class PathUtility
+{
+    /**
+     * Public URLs returned from TYPO3 are inconsistent.
+     * Therefore we need to strip an optinal leading slash.
+     *
+     */
+    public static function stripLeadingSlash(string $filename): string
+    {
+        return ltrim($filename, '/');
+    }
+
+}


### PR DESCRIPTION
Unfortunately the response from `getPath()` in TYPO3 is not consistent. Sometimes it contains a leading slash sometimes it doesn't.

There was already one occurrence where leading slashes were removed.

This change introduces a simple static method `PathUtility::stripLeadingSlash()` which is then used everywhere a path is read from or written to the database.