### PR TITLE
bugfix || disable processing for unsupported file types

### DIFF
--- a/Classes/Resource/Processing/DeferredImageProcessor.php
+++ b/Classes/Resource/Processing/DeferredImageProcessor.php
@@ -19,7 +19,11 @@ class DeferredImageProcessor extends LocalImageProcessor
             && $task->getSourceFile()->getMimeType() !== 'image/svg+xml'
             && $task->getSourceFile()->getExtension() !== 'svg'
             && $task->getSourceFile()->getMimeType() !== 'application/pdf'
-            && $task->getSourceFile()->getExtension() !== 'pdf';
+            && $task->getSourceFile()->getExtension() !== 'pdf'
+            && $task->getSourceFile()->getMimeType() !== 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+            && $task->getSourceFile()->getExtension() !== 'docx'
+            && $task->getSourceFile()->getMimeType() !== 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+            && $task->getSourceFile()->getExtension() !== 'pptx';
     }
 
     public function processTask(TaskInterface $task): void

--- a/Classes/Resource/Processing/DeferredImageProcessor.php
+++ b/Classes/Resource/Processing/DeferredImageProcessor.php
@@ -20,8 +20,16 @@ class DeferredImageProcessor extends LocalImageProcessor
             && $task->getSourceFile()->getExtension() !== 'svg'
             && $task->getSourceFile()->getMimeType() !== 'application/pdf'
             && $task->getSourceFile()->getExtension() !== 'pdf'
+            && $task->getSourceFile()->getMimeType() !== 'application/msword'
+            && $task->getSourceFile()->getExtension() !== 'doc'
             && $task->getSourceFile()->getMimeType() !== 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
             && $task->getSourceFile()->getExtension() !== 'docx'
+            && $task->getSourceFile()->getMimeType() !== 'application/application/vnd.ms-excel'
+            && $task->getSourceFile()->getExtension() !== 'xls'
+            && $task->getSourceFile()->getMimeType() !== 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+            && $task->getSourceFile()->getExtension() !== 'xlsx'
+            && $task->getSourceFile()->getMimeType() !== 'application/vnd.ms-powerpoint'
+            && $task->getSourceFile()->getExtension() !== 'ppt'
             && $task->getSourceFile()->getMimeType() !== 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
             && $task->getSourceFile()->getExtension() !== 'pptx';
     }


### PR DESCRIPTION
Some content types in TYPO3 (e.g. uploads / file links) have the option to enable thumbnails. This works for most file types for images and PDFs, but not for Microsoft-related file types (e.g. .docx). When using this extension on a site that has content elements (e.g file links with enabled thumbnails)  with file types like mentioned above, an exception will occur, as there is no image to be processed.

Simply disabling deferred image processing for this unsupported file types should prevent the exception.