### PR TITLE
[FEATURE] TYPO3 CMS 13 compatibility

### DIFF
--- a/Classes/Resource/Processing/DeferredImageProcessor.php
+++ b/Classes/Resource/Processing/DeferredImageProcessor.php
@@ -6,6 +6,7 @@ namespace WEBcoast\DeferredImageProcessing\Resource\Processing;
 
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use TYPO3\CMS\Core\Imaging\ImageDimension;
@@ -16,6 +17,7 @@ use TYPO3\CMS\Core\Resource\Processing\TaskTypeRegistry;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use WEBcoast\DeferredImageProcessing\Event\ShouldDeferEvent;
 
+#[Autoconfigure(public: true)]
 class DeferredImageProcessor extends LocalImageProcessor
 {
     protected EventDispatcherInterface $eventDispatcher;
@@ -34,8 +36,7 @@ class DeferredImageProcessor extends LocalImageProcessor
             && $task->getSourceFile()->getProperty('width') > 0
             && $task->getSourceFile()->getProperty('height') > 0
             && $task->getSourceFile()->getMimeType() !== 'image/svg+xml'
-            && $task->getSourceFile()->getMimeType() !== 'application/pdf'
-        ;
+            && $task->getSourceFile()->getMimeType() !== 'application/pdf';
     }
 
     public function processTask(TaskInterface $task): void
@@ -81,9 +82,9 @@ class DeferredImageProcessor extends LocalImageProcessor
 
         $imageDimension = ImageDimension::fromProcessingTask($task);
         if (!$task->getConfiguration()['crop']
-        &&  $imageDimension->getWidth() === $task->getTargetFile()->getOriginalFile()->getProperty('width')
-        &&  $imageDimension->getHeight() === $task->getTargetFile()->getOriginalFile()->getProperty('height')
-        &&  $task->getTargetFile()->getExtension() === $task->getTargetFile()->getOriginalFile()->getExtension()
+            && $imageDimension->getWidth() === $task->getTargetFile()->getOriginalFile()->getProperty('width')
+            && $imageDimension->getHeight() === $task->getTargetFile()->getOriginalFile()->getProperty('height')
+            && $task->getTargetFile()->getExtension() === $task->getTargetFile()->getOriginalFile()->getExtension()
         ) {
             // If the target image dimensions are identical to the original file and no cropping is defined, do not process, but use the original file
             $task->setExecuted(true);// keep!

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -3,14 +3,7 @@ services:
       autowire: true
       autoconfigure: true
       public: false
-      
-      # Register the command to process deferred image processing entries
-   WEBcoast\DeferredImageProcessing\Command\ProcessCommand:
-      tags:
-         -  name: 'console.command'
-            command: 'deferred_image_processing:process'
-            description: 'Process all entries in deferred image processing file list'
-            hidden: false
 
-   WEBcoast\DeferredImageProcessing\Resource\Processing\DeferredImageProcessor:
-      public: true
+   WEBcoast\DeferredImageProcessing\:
+        resource: '../Classes/*'
+        exclude: '../Classes/Event/*'

--- a/composer.json
+++ b/composer.json
@@ -7,15 +7,16 @@
     "license": "GPL-3.0-or-later",
     "extra": {
         "branch-alias": {
-            "dev-main": "2.0.x-dev"
+            "dev-main": "3.0.x-dev"
         },
         "typo3/cms": {
             "extension-key": "deferred_image_processing"
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
-        "typo3/cms-core": "^11.5 || ^12.4"
+        "php": "^8.1",
+        "typo3/cms-core": "^12.4 || ^13.4",
+        "typo3/cms-frontend": "^12.4 || ^13.4"
     },
     "autoload": {
         "psr-4": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -11,8 +11,8 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'WEBcoast',
     'constraints' => [
         'depends' => [
-            'php' => '7.4.0-8.99.99',
-            'typo3' => '11.5.0-12.4.99'
+            'php' => '8.1.0-8.99.99',
+            'typo3' => '12.4.0-13.4.99'
         ]
     ]
 ];


### PR DESCRIPTION
* improve process command:
  * remove `verbose` option from command
  * configure and use `status` option correctly
  * check for verbosity correctly
  * return early if no files are pending processing
* update dependency injection configuration
* update TYPO3 CMS and PHP dependency
* update branch alias